### PR TITLE
enable assertions for gradle run task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 
 application {
     mainClass.set("h08.Main")
+    applicationDefaultJvmArgs += "-ea"
 }
 
 tasks {


### PR DESCRIPTION
Add "-ea" to the default JVM arguments to enable the execution of assert statements when using the gradle task application/run